### PR TITLE
re-enqueue の機構を使って depth 相当のものを実装してみる

### DIFF
--- a/re_enqueue_crawlers/Gemfile
+++ b/re_enqueue_crawlers/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "rake"
+gem "daimon_skycrawlers"

--- a/re_enqueue_crawlers/Gemfile.lock
+++ b/re_enqueue_crawlers/Gemfile.lock
@@ -1,0 +1,105 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionpack (5.0.0.1)
+      actionview (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      rack (~> 2.0)
+      rack-test (~> 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    actionview (5.0.0.1)
+      activesupport (= 5.0.0.1)
+      builder (~> 3.1)
+      erubis (~> 2.7.0)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.0.2)
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    amq-protocol (2.0.1)
+    arel (7.1.4)
+    builder (3.2.2)
+    bunny (2.6.0)
+      amq-protocol (>= 2.0.1)
+    concurrent-ruby (1.0.2)
+    daimon_skycrawlers (0.4.0)
+      activerecord
+      bundler (~> 1.11)
+      faraday
+      faraday_middleware
+      nokogiri
+      pg
+      railties
+      sitemap-parser
+      songkick_queue
+      thor
+      timers
+      webrobots
+    erubis (2.7.0)
+    ethon (0.9.1)
+      ffi (>= 1.3.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.0)
+      faraday (>= 0.7.4, < 0.10)
+    ffi (1.9.14)
+    hitimes (1.2.4)
+    i18n (0.7.0)
+    loofah (2.0.3)
+      nokogiri (>= 1.5.9)
+    method_source (0.8.2)
+    mini_portile2 (2.1.0)
+    minitest (5.9.1)
+    multipart-post (2.0.0)
+    nokogiri (1.6.8.1)
+      mini_portile2 (~> 2.1.0)
+    pg (0.19.0)
+    rack (2.0.1)
+    rack-test (0.6.3)
+      rack (>= 1.0)
+    rails-dom-testing (2.0.1)
+      activesupport (>= 4.2.0, < 6.0)
+      nokogiri (~> 1.6.0)
+    rails-html-sanitizer (1.0.3)
+      loofah (~> 2.0)
+    railties (5.0.0.1)
+      actionpack (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      method_source
+      rake (>= 0.8.7)
+      thor (>= 0.18.1, < 2.0)
+    rake (11.3.0)
+    sitemap-parser (0.3.0)
+      nokogiri (~> 1.6)
+      typhoeus (~> 0.6)
+    songkick_queue (1.0.0)
+      activesupport (>= 3.0.0)
+      bunny (~> 2.2)
+    thor (0.19.1)
+    thread_safe (0.3.5)
+    timers (4.1.1)
+      hitimes
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    webrobots (0.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  daimon_skycrawlers
+  rake
+
+BUNDLED WITH
+   1.13.2

--- a/re_enqueue_crawlers/README.md
+++ b/re_enqueue_crawlers/README.md
@@ -1,0 +1,50 @@
+# re_enqueue_crawlers
+
+TODO: Write description.
+
+## Requirements
+
+- Ruby
+- RabbitMQ
+- RDB
+  - PostgreSQL (default)
+  - MySQL
+  - SQLite3
+
+## Usage
+
+1. Install dependencies
+
+```
+$ bundle install
+```
+
+2. Create database
+
+```
+$ bundle exec rake db:create
+$ bundle exec rake db:migrate
+```
+
+3. Open new terminal and run crawler/processor
+
+```
+$ bin/crawler   # on new terminal
+$ bin/processor # on new terminal
+```
+
+4. Enqueue task
+
+```
+$ bin/enqueue url http://example.com/
+```
+
+5. You'll see `It works with 'http://example.com'` on your terminal which runs your processor!
+
+6. You can re-enqueue task for processor
+
+```
+$ bin/enqueue response http://example.com/
+```
+
+Display `It works with 'http://example.com'` again on your terminal which runs your processor.

--- a/re_enqueue_crawlers/Rakefile
+++ b/re_enqueue_crawlers/Rakefile
@@ -1,0 +1,1 @@
+require "daimon_skycrawlers/tasks"

--- a/re_enqueue_crawlers/app/crawlers/sample_crawler.rb
+++ b/re_enqueue_crawlers/app/crawlers/sample_crawler.rb
@@ -1,0 +1,8 @@
+require "daimon_skycrawlers/crawler"
+require "daimon_skycrawlers/crawler/default"
+
+base_url = "http://example.com"
+
+crawler = DaimonSkycrawlers::Crawler::Default.new(base_url)
+
+DaimonSkycrawlers.register_crawler(crawler)

--- a/re_enqueue_crawlers/app/processors/sample_processor.rb
+++ b/re_enqueue_crawlers/app/processors/sample_processor.rb
@@ -1,0 +1,5 @@
+require "daimon_skycrawlers/processor"
+
+DaimonSkycrawlers.register_processor do |data|
+  p "It works with '#{data[:url]}'"
+end

--- a/re_enqueue_crawlers/config/database.yml
+++ b/re_enqueue_crawlers/config/database.yml
@@ -1,0 +1,26 @@
+# PostgreSQL. Versions 8.2 and up are supported.
+#
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 5
+
+development:
+  <<: *default
+  database: re_enqueue_crawlers_development
+  #username: re_enqueue_crawlers
+  #password:
+  #host: localhost
+  #port: 5432
+  #schema_search_path: myapp,sharedapp,public
+  #min_messages: notice
+
+test:
+  <<: *default
+  database: re_enqueue_crawlers_test
+
+production:
+  <<: *default
+  database: re_enqueue_crawlers_production
+  username: re_enqueue_crawlers
+  password: <%= ENV['RE_ENQUEUE_CRAWLERS_PASSWORD'] %>

--- a/re_enqueue_crawlers/config/init.rb
+++ b/re_enqueue_crawlers/config/init.rb
@@ -6,6 +6,8 @@ require "daimon_skycrawlers/queue"
 DaimonSkycrawlers.configure do |config|
   config.logger = DaimonSkycrawlers::Logger.default
   config.crawler_interval = 1
+
+  config.shutdown_interval = 30
 end
 
 DaimonSkycrawlers::Queue.configure do |config|

--- a/re_enqueue_crawlers/config/init.rb
+++ b/re_enqueue_crawlers/config/init.rb
@@ -1,0 +1,21 @@
+require "bundler/setup"
+require "daimon_skycrawlers"
+require "daimon_skycrawlers/logger"
+require "daimon_skycrawlers/queue"
+
+DaimonSkycrawlers.configure do |config|
+  config.logger = DaimonSkycrawlers::Logger.default
+  config.crawler_interval = 1
+end
+
+DaimonSkycrawlers::Queue.configure do |config|
+  #  queue configuration
+  config.logger = DaimonSkycrawlers.configuration.logger
+  config.host = "127.0.0.1"
+  config.port = 5672
+  # config.username = 'guest'
+  # config.password = 'guest'
+  config.vhost = "/"
+  config.max_reconnect_attempts = 10
+  config.network_recovery_interval = 1.0
+end

--- a/re_enqueue_crawlers/db/migrate/20161017034337_create_page.rb
+++ b/re_enqueue_crawlers/db/migrate/20161017034337_create_page.rb
@@ -1,0 +1,12 @@
+class CreatePage < ActiveRecord::Migration[5.0]
+  def change
+    create_table :pages do |t|
+      t.string :url
+      t.text :headers
+      t.binary :body
+      t.datetime :last_modified_at
+      t.string :etag
+      t.string :timestamps
+    end
+  end
+end

--- a/re_enqueue_crawlers/db/schema.rb
+++ b/re_enqueue_crawlers/db/schema.rb
@@ -1,0 +1,27 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 20161017034337) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "pages", force: :cascade do |t|
+    t.string   "url"
+    t.text     "headers"
+    t.binary   "body"
+    t.datetime "last_modified_at"
+    t.string   "etag"
+    t.string   "timestamps"
+  end
+
+end


### PR DESCRIPTION
## やること
Connpass の一覧ページをスクレイピングしてくるコードを拡張する。
イベント詳細ページの各データを取得し保存するまでを re-enqueue のしくみを使って実装する。

## 処理の流れ

1. Connpass の検索クエリを含んだ URL をエンキューする
1. Crawler が GET する。一覧ページを取得し保存する。
1. Processor が、一覧ページをパースしてリンクの href を re-enqueue する。
1. Crawler が GET する。詳細ページを取得し保存する。
1. Processor が、詳細ページをパースしてイベントタイトルや会場住所を取り出し、保存する。

## 考えてること

- 3 と 5 で使われる Processor は明らかに別物である。
- 5 について。取得して来られる（イベント詳細ページの）リンクの URL とかリンクテキストなんて事前にわかるわけないと思うのだけど、Processor はどうやってフィルタリングするんだろう。正規表現もやりようがない気がする...。